### PR TITLE
Added ability to seed the time component of the id

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm install --save ulid
 import ulid from 'ulid'
 
 ulid() // 01ARZ3NDEKTSV4RRFFQ69G5FAV
+
+// You can also input a seed time which will consistently give you the same time component
+// This is useful for migrating to ulid
+ulid(1469918176385) // 01ARYZ6S41TSV4RRFFQ69G5FAV
 ```
 
 ## Implementations in other languages

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ function factory(prng) {
   function ulid(seedTime) {
     if(!seedTime) {
       seedTime = Date.now();
+    } else if(isNaN(seedTime) || typeof seedTime !== 'number') {
+      throw new Error(seedTime + ' must be a number');
     }
     
     return encodeTime(seedTime, TIME_LEN) + encodeRandom(RANDOM_LEN)

--- a/index.js
+++ b/index.js
@@ -10,17 +10,17 @@ function factory(prng) {
   var TIME_LEN = 10
   var RANDOM_LEN = 16
 
-  function encodeTime(now, len) {
-    if (now > TIME_MAX) {
+  function encodeTime(time, len) {
+    if (time > TIME_MAX) {
       throw new Error("cannot encode time greater than " + TIME_MAX)
     }
     var mod
-    var now
+    var time
     var str = ""
     for (var x = len; x > 0; x--) {
-      mod = now % ENCODING_LEN
+      mod = time % ENCODING_LEN
       str = ENCODING.charAt(mod) + str
-      now = (now - mod) / ENCODING_LEN
+      time = (time - mod) / ENCODING_LEN
     }
     return str
   }
@@ -35,8 +35,12 @@ function factory(prng) {
     return str
   }
 
-  function ulid() {
-    return encodeTime(Date.now(), TIME_LEN) + encodeRandom(RANDOM_LEN)
+  function ulid(seedTime) {
+    if(!seedTime) {
+      seedTime = Date.now();
+    }
+    
+    return encodeTime(seedTime, TIME_LEN) + encodeRandom(RANDOM_LEN)
   }
 
   ulid.prng = prng

--- a/test.js
+++ b/test.js
@@ -50,6 +50,10 @@ describe('ulid', function() {
       assert.strictEqual(26, ulid().length)
     })
 
+    it('should return expected encoded time component result', function() {
+      assert.strictEqual('01ARYZ6S41', ulid(1469918176385).substring(0, 10))
+    })
+
   })
 
 })

--- a/test.js
+++ b/test.js
@@ -54,6 +54,10 @@ describe('ulid', function() {
       assert.strictEqual('01ARYZ6S41', ulid(1469918176385).substring(0, 10))
     })
 
+    it('should throw an error if seed is not a number', function() {
+      assert.throws(() => ulid('test'), Error)
+    })
+
   })
 
 })


### PR DESCRIPTION
I need a way to be able to migrate my old database to use ulid. In order for me to do that, I need to be able to seed the time component so that I can still sort the migrated data and new data using the id.