### PR TITLE
Add a simple CLI command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,4 @@
+#! /usr/bin/env node
+
+const ulid = require('./index')
+console.log(ulid())

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   "scripts": {
     "test": "./node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
     "perf": "./node_modules/.bin/matcha perf.js"
-  }
+  },
+  "bin": "./cli.js"
 }


### PR DESCRIPTION
With `npx` now bundled by default with `npm` it's even more useful to have a CLI command and all the easier to run: just `npx ulid` (after the contents of the PR may be published) whether it is installed locally, globally, or not at all and `npx` will download a temporary install if need be or use whichever one it finds locally or globally.

Resolves #25 